### PR TITLE
Fix typos in ScienceDefs.cfg

### DIFF
--- a/GameData/RocketEmporium/ScienceDefs.cfg
+++ b/GameData/RocketEmporium/ScienceDefs.cfg
@@ -16,14 +16,14 @@ EXPERIMENT_DEFINITION
 		default = You get some great shots of the environment! Just a few more and you'll probably get to go home again...
 
 		KerbinSrfLandedLaunchPad = Great! We can use this in our promotional material.
-		KerbinSrfLandedRunway = If we just edit out the cracks from the runway, this will look awesome in our next pampfhlet!
+		KerbinSrfLandedRunway = If we just edit out the cracks from the runway, this will look awesome in our next pamphlet!
 		KerbinSrfLandedKSC = Finally home again! Wait, have we even left? 
 		KerbinSrfLandedSPH = Is that Bob grabbing cookies from the drawer, behind that window? 
 		KerbinSrfLandedDesert = The sand may look like it is empty of life, but minor tracks can be seen in the sand, indicating some animals may crawl out of the dunes during night.
 		KerbinSrfLandedShores = What we sea here isn't exactly science-fishin. Oar is it? - That's reely not cod puns. - Shore it is!
 		KerbinSrfLandedWater = ?
 		KerbinSrfLandedIceCaps = We might benefit from building a science station here. But... let us send the interns...
-		KerbinSrfLandedBadlands = Judging from the foilage, this might be a great place to grow carrots. 
+		KerbinSrfLandedBadlands = Judging from the foliage, this might be a great place to grow carrots. 
 		
 		MunSrfLanded = Grey rocks as far as the camera can see... let's never send a manned crew to this place!
 	}


### PR DESCRIPTION
Just a quick PR to fix two misspellings in the Camera science report definitions. Lovin' this mod!